### PR TITLE
OC-40: Added a sed to remove the line that sets the (deprecated) temp…

### DIFF
--- a/puppet/install-puppet.sh
+++ b/puppet/install-puppet.sh
@@ -18,4 +18,7 @@ sudo apt-get install -y puppet
 echo "running puppet --version";
 echo $(puppet --version)
 
+echo "removing templatedir setting from puppet.conf";
+sudo sed -i '/^templatedir/d' /etc/puppet/puppet.conf
+
 exit 0;


### PR DESCRIPTION
Removed the templatedir line from puppet.conf using a sed in the install-puppet.sh script.
The puppet script runs without warnings now.