### PR TITLE
OC-289 Fixed HOME environment variable in create-symlinks script

### DIFF
--- a/scripts/create-symlinks.sh
+++ b/scripts/create-symlinks.sh
@@ -1,134 +1,94 @@
 #!/bin/bash
 
-if [ ! $HOME ]
+echo "Extending OSGP development environment for OSGP & SSS development ..."
+
+if [ $HOME ]
 then
-    echo "HOME dir was not set, setting to /home/dev"
-    HOME=/home/dev
+    SOURCEDIR=$HOME/Sources/SmartSocietyServices
+    echo "HOME dir was set, source directory is $SOURCEDIR"
+else
+    SOURCEDIR=/home/dev/Sources/SmartSocietyServices
+    echo "HOME dir was not set, source directory is $SOURCEDIR"
 fi
+TARGETDIR=/etc/osp/
 
-SOURCEDIR=$HOME/Sources/OSGP
-TARGETDIR=/etc/osp
+echo "- copying the automatic tests files to $TARGETDIR/test ..."
+cp -f $SOURCEDIR/Smart-Meter-Integration/cucumber-integration-tests/src/test/resources/sm-integration-cucumber.properties $TARGETDIR/samples/test/
+cp -f $SOURCEDIR/Integration-Tests/cucumber-tests-webapps-web-core/src/test/resources/cucumber-webapps.properties $TARGETDIR/samples/test/
 
-echo "Setting up OSGP development environment ..."
+echo "- copying the SSS configuration files to $TARGETDIR/samples and extending them with .sample ..."
+cp -f $SOURCEDIR/Smart-Meter-Integration/sm-integration/src/main/resources/sm-integration.properties $TARGETDIR/samples/sm-integration.properties.sample
+cp -f $SOURCEDIR/Smart-Meter-Integration/sm-integration/src/main/resources/logback.xml $TARGETDIR/samples/sm-integration-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/web-owner/src/main/resources/web-owner.properties $TARGETDIR/samples/web-owner.properties.sample
+cp -f $SOURCEDIR/Webapps/web-owner/src/main/resources/logback.xml $TARGETDIR/samples/web-owner-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/web-operator/src/main/resources/web-operator.properties $TARGETDIR/samples/web-operator.properties.sample
+cp -f $SOURCEDIR/Webapps/web-operator/src/main/resources/logback.xml $TARGETDIR/samples/web-operator-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/proxy-server/src/main/resources/proxy-server.properties $TARGETDIR/samples/proxy-server.properties.sample
+cp -f $SOURCEDIR/Webapps/proxy-server/src/main/resources/logback.xml $TARGETDIR/samples/proxy-server-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/osgp-webservice-client/src/main/resources/osgp-webservice-client.properties $TARGETDIR/samples/osgp-webservice-client.properties.sample
+cp -f $SOURCEDIR/Webapps/web-api-user-management/src/main/resources/web-api-user-management.properties $TARGETDIR/samples/web-api-user-management.properties.sample
+cp -f $SOURCEDIR/Webapps/web-api-user-management/src/main/resources/logback.xml $TARGETDIR/samples/web-api-user-management-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/web-api-net-management/src/main/resources/web-api-net-management.properties $TARGETDIR/samples/web-api-net-management.properties.sample
+cp -f $SOURCEDIR/Webapps/web-api-net-management/src/main/resources/logback.xml $TARGETDIR/samples/web-api-net-management-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/web-api-installation/src/main/resources/web-api-installation.properties $TARGETDIR/samples/web-api-installation.properties.sample
+cp -f $SOURCEDIR/Webapps/web-api-installation/src/main/resources/logback.xml $TARGETDIR/samples/web-api-installation-logback.xml.sample
+cp -f $SOURCEDIR/Webapps/osgp-simulator-dlms-triggered/src/main/resources/logback.xml $TARGETDIR/samples/osgp-simulator-dlms-triggered-logback.xml.sample
 
-# Create configuration directories and standard files.
-echo "- creating $TARGETDIR ..."
-sudo mkdir -p $TARGETDIR
-sudo chown -R dev:dev $TARGETDIR
+echo "- configuring proxyserver related files ..."
+sudo mkdir -p /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/flexovlca/certs/proxy-server/sign-key.der /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/flexovlca/certs/proxy-server/verify-key.der /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.crt /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.ks /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.ts /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.crt /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.ks /etc/ssl/certs/proxy-server/
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.ts /etc/ssl/certs/proxy-server/
 
-echo "- creating samples $TARGETDIR directory and $TARGETDIR/samples/Readme.md with directions about the sample files ..."
-mkdir -p $TARGETDIR/samples
-echo "OSGP Samples directory" > $TARGETDIR/samples/Readme.md
-echo "" >> $TARGETDIR/samples/Readme.md
-echo "This directory contains samples files how you could configure OSGP. These files will not be used. Use them by copying them to $TARGETDIR and remove the .sample extension." >> $TARGETDIR/samples/Readme.md
-echo "- *.properties.sample: Example property files for the given module." >> $TARGETDIR/samples/Readme.md
-echo "- *-logback.xml.sample: Example logback files for the given module." >> $TARGETDIR/samples/Readme.md
+echo "- create $TARGETDIR/mailtemplates directory and linking files ..."
+mkdir -p /etc/osp/mailtemplates/
+ln -sf $HOME/Sources/SmartSocietyServices/Configuration/developers/master-template.html /etc/osp/mailtemplates/
+dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/mailtemplates"
+target="/etc/osp/mailtemplates/"
+for f in "$dir"/*; do
+  ln -sf "$f" "$target"
+done
+dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/mailtemplates/web-installation"
+for f in "$dir"/*; do
+  ln -sf "$f" "$target"
+done
 
-echo "- creating $TARGETDIR/test directory for automatic tests configuration ..."
-mkdir -p $TARGETDIR/test
-[ ! -f $TARGETDIR/global.properties ] && echo "# Global properties" > $TARGETDIR/global.properties
-[ ! -f $TARGETDIR/test/global-cucumber.properties ] && echo "# Global cucumber properties" > $TARGETDIR/test/global-cucumber.properties 
+mkdir -p /etc/osp/shipment/
+mkdir -p /etc/osp/substations/
 
-echo "- setting security provider to SunPKCS11-NSS ..."
-[ $(/bin/grep -c signing.server.security.provider\=SunPKCS11-NSS $TARGETDIR/global.properties) -eq 0 ] && echo "signing.server.security.provider=SunPKCS11-NSS" >> $TARGETDIR/global.properties
-[ $(/bin/grep -c oslp.security.provider\=SunPKCS11-NSS $TARGETDIR/global.properties) -eq 0 ] && echo "oslp.security.provider=SunPKCS11-NSS" >> $TARGETDIR/global.properties
+echo "- create $TARGETDIR/styling directory and linking files ..."
+mkdir -p /etc/osp/styling/
+dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/css"
+target="/etc/osp/styling/"
+for f in "$dir"/*; do
+  ln -sf "$f" "$target"
+done
 
-# Now create all configuration sample files.
-mkdir -p $TARGETDIR/samples/test
-echo "- copying automatic tests configuration files to $TARGETDIR/test directory ..."
-cp $SOURCEDIR/Integration-Tests/cucumber-tests-platform/src/test/resources/cucumber-platform.properties $TARGETDIR/samples/test/
-cp $SOURCEDIR/Integration-Tests/cucumber-tests-platform-dlms/src/test/resources/cucumber-platform-dlms.properties $TARGETDIR/samples/test/
-
-echo "- copying OSGP configuration files to $TARGETDIR/samples directory and extending them with .sample ..."
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-admin/src/main/resources/osgp-adapter-domain-admin.properties $TARGETDIR/samples/osgp-adapter-domain-admin.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-admin/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-admin-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-core/src/main/resources/osgp-adapter-domain-core.properties $TARGETDIR/samples/osgp-adapter-domain-core.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-core-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-microgrids/src/main/resources/osgp-adapter-domain-microgrids.properties $TARGETDIR/samples/osgp-adapter-domain-microgrids.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-microgrids/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-microgrids-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-publiclighting/src/main/resources/osgp-adapter-domain-publiclighting.properties $TARGETDIR/samples/osgp-adapter-domain-publiclighting.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-publiclighting/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-publiclighting-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-smartmetering/src/main/resources/osgp-adapter-domain-smartmetering.properties $TARGETDIR/samples/osgp-adapter-domain-smartmetering.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-smartmetering/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-smartmetering-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-tariffswitching/src/main/resources/osgp-adapter-domain-tariffswitching.properties $TARGETDIR/samples/osgp-adapter-domain-tariffswitching.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-domain-tariffswitching/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-tariffswitching-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties $TARGETDIR/samples/osgp-adapter-protocol-dlms.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-protocol-adapter-dlms/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-dlms-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-protocol-adapter-iec61850/src/main/resources/osgp-adapter-protocol-iec61850.properties $TARGETDIR/samples/osgp-adapter-protocol-iec61850.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-protocol-adapter-iec61850/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-iec61850-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp/src/main/resources/osgp-adapter-protocol-oslp.properties $TARGETDIR/samples/osgp-adapter-protocol-oslp.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-oslp-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties $TARGETDIR/samples/osgp-adapter-protocol-oslp-elster.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp-elster/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-oslp-elster-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-admin/src/main/resources/osgp-adapter-ws-admin.properties $TARGETDIR/samples/osgp-adapter-ws-admin.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-admin/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-admin-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties $TARGETDIR/samples/osgp-adapter-ws-core.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-core-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-shared-db/src/main/resources/osgp-adapter-ws-shared-db.properties $TARGETDIR/samples/osgp-adapter-ws-shared-db.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-microgrids/src/main/resources/osgp-adapter-ws-microgrids.properties $TARGETDIR/samples/osgp-adapter-ws-microgrids.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-microgrids/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-microgrids-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-publiclighting/src/main/resources/osgp-adapter-ws-publiclighting.properties $TARGETDIR/samples/osgp-adapter-ws-publiclighting.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-publiclighting/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-publiclighting-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties $TARGETDIR/samples/osgp-adapter-ws-smartmetering.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-smartmetering/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-smartmetering-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-tariffswitching/src/main/resources/osgp-adapter-ws-tariffswitching.properties $TARGETDIR/samples/osgp-adapter-ws-tariffswitching.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-adapter-ws-tariffswitching/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-tariffswitching-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-core/src/main/resources/osgp-core.properties $TARGETDIR/samples/osgp-core.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-core-logback.xml.sample
-cp -f $SOURCEDIR/Platform/osgp-logging/src/main/resources/osgp-logging.properties $TARGETDIR/samples/osgp-logging.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-logging/src/main/resources/logback.xml $TARGETDIR/samples/osgp-logging-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/signing-server/src/main/resources/signing-server.properties $TARGETDIR/samples/signing-server.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/signing-server/src/main/resources/logback.xml $TARGETDIR/samples/signing-server-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/web-device-simulator/src/main/resources/web-device-simulator.properties $TARGETDIR/samples/web-device-simulator.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/web-device-simulator/src/main/resources/logback.xml $TARGETDIR/samples/web-device-simulator-logback.xml.sample
-cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-core-db-api/src/main/resources/osgp-core-db-api.properties $TARGETDIR/samples/osgp-core-db-api.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-core-db-api-iec61850/src/main/resources/osgp-core-db-api-iec61850.properties $TARGETDIR/samples/osgp-core-db-api-iec61850.properties.sample
-cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-jasper-interface/src/main/resources/jasper-interface.properties $TARGETDIR/samples/jasper-interface.properties.sample
-cp -f $SOURCEDIR/Platform/osgp-domain-logging/src/main/resources/osgp-domain-logging.properties $TARGETDIR/samples/osgp-domain-logging.properties.sample
-
-echo "- creating symlinks to device simulator ECDSA keypair ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_private.der /etc/ssl/certs
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_public.der /etc/ssl/certs
-
-echo "- create symlinks to platform ECDSA keypair ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_private.der /etc/ssl/certs
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_public.der /etc/ssl/certs
-
-echo "- create symlinks to secret.aes ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/secret.aes /etc/ssl/certs
-
-echo "- create symlink to CA certificate ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/cacert.cer /etc/ssl/certs
-
-echo "- create symlink to LianderNetManagement.pfx ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/LianderNetManagement.pfx /etc/ssl/certs
-
-echo "- create symlink to server certificate ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/localhost.cert.pem /etc/ssl/certs
-
-echo "- create symlink to server private key ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/private/localhost.key.pem /etc/ssl/private
-
-echo "- create symlink to keystore ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/trust.jks /etc/ssl/certs
+echo "- create $TARGETDIR/logos directory and linking files ..."
+mkdir -p /etc/osp/logos/
+dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/logos"
+target="/etc/osp/logos/"
+for f in "$dir"/*; do
+  ln -sf "$f" "$target"
+done
 
 echo "- create symlink to apache vhost and remove the link to the 000-default.conf vhost ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/apache-httpd/vhost.conf /etc/apache2/sites-enabled
-sudo rm -f /etc/apache2/sites-enabled/000-default.conf
+sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/developers/apache2/flexovl-vhost /etc/apache2/sites-enabled/vhost.conf
 sudo service apache2 restart
 
-# Create sym-link to build script. 
-ln -sf $HOME/Sources/OSGP/Config/scripts/build_osgp_sources.sh $HOME/Sources/OSGP/b.sh
+echo "- creating build script for SSS in $HOME/Sources/SmartSocietyServices ..."
+ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/build_sss_sources.sh $HOME/Sources/SmartSocietyServices/b.sh
 
-echo "- create scripts dir in $HOME ..."
-mkdir -p $HOME/scripts
+echo "- creating SSS link to $HOME/Sources/SmartSocietyServices ..."
+[ ! -L $HOME/Sources/SSS ] && ln -sf $HOME/Sources/SmartSocietyServices/ $HOME/Sources/SSS
 
-ln -sf $HOME/Sources/OSGP/Config/scripts/create_backup_osgp_dbs.sh $HOME/scripts/create_backup_osgp_dbs.sh
-ln -sf $HOME/Sources/OSGP/Config/scripts/restore_backup_osgp_dbs.sh $HOME/scripts/restore_backup_osgp_dbs.sh
+echo "- creating links to create backup and restore databases ..."
+ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/create_backup_osgp_and_sss_dbs.sh $HOME/scripts/
+ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/restore_backup_osgp_and_sss_dbs.sh $HOME/scripts/
 
-# Add scripts path to the path so that the development scripts can be found (introduced for database backup scripts
-! grep -q "$HOME/scripts" $HOME/.bashrc && echo "PATH=\"$HOME/scripts:\$PATH\"" >> $HOME/.bashrc
-# Adds cm2 alias so that you can easily clean your maven repository before building (e.g. `cm2 && mvn install`).
-! grep -q "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" $HOME/.bashrc && echo "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" >> $HOME/.bashrc
-
-echo "Done setting up OSGP development environment."
+echo "Done extending the OSGP development environment for OSGP & SSS development."

--- a/scripts/create-symlinks.sh
+++ b/scripts/create-symlinks.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ ! $HOME ]
+then
+    echo "HOME dir was not set, setting to /home/dev"
+    HOME=/home/dev
+fi
+
 SOURCEDIR=$HOME/Sources/OSGP
 TARGETDIR=/etc/osp
 

--- a/scripts/create-symlinks.sh
+++ b/scripts/create-symlinks.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
-if [ ! $HOME ]
+BASE=$HOME
+
+# If no HOME directory was set, use a BASE directory that is /home/dev
+if [ ! $BASE ]
 then
-    echo "HOME dir was not set, setting to /home/dev"
-    HOME=/home/dev
+    BASE=/home/dev
 fi
 
-SOURCEDIR=$HOME/Sources/OSGP
+SOURCEDIR=$BASE/Sources/OSGP
 TARGETDIR=/etc/osp
 
+echo "BASE is $BASE, SOURCEDIR=$SOURCEDIR"
 echo "Setting up OSGP development environment ..."
 
 # Create configuration directories and standard files.
@@ -87,48 +90,48 @@ cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-jasper-interface/src/main/resources/
 cp -f $SOURCEDIR/Platform/osgp-domain-logging/src/main/resources/osgp-domain-logging.properties $TARGETDIR/samples/osgp-domain-logging.properties.sample
 
 echo "- creating symlinks to device simulator ECDSA keypair ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_private.der /etc/ssl/certs
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_public.der /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_private.der /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_public.der /etc/ssl/certs
 
 echo "- create symlinks to platform ECDSA keypair ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_private.der /etc/ssl/certs
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_public.der /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_private.der /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_public.der /etc/ssl/certs
 
 echo "- create symlinks to secret.aes ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/secret.aes /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/oslp/secret.aes /etc/ssl/certs
 
 echo "- create symlink to CA certificate ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/cacert.cer /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/cacert.cer /etc/ssl/certs
 
 echo "- create symlink to LianderNetManagement.pfx ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/LianderNetManagement.pfx /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/LianderNetManagement.pfx /etc/ssl/certs
 
 echo "- create symlink to server certificate ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/localhost.cert.pem /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/localhost.cert.pem /etc/ssl/certs
 
 echo "- create symlink to server private key ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/private/localhost.key.pem /etc/ssl/private
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/private/localhost.key.pem /etc/ssl/private
 
 echo "- create symlink to keystore ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/certificates/trust.jks /etc/ssl/certs
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/trust.jks /etc/ssl/certs
 
 echo "- create symlink to apache vhost and remove the link to the 000-default.conf vhost ..."
-sudo ln -sf $HOME/Sources/OSGP/Config/apache-httpd/vhost.conf /etc/apache2/sites-enabled
+sudo ln -sf $BASE/Sources/OSGP/Config/apache-httpd/vhost.conf /etc/apache2/sites-enabled
 sudo rm -f /etc/apache2/sites-enabled/000-default.conf
 sudo service apache2 restart
 
 # Create sym-link to build script. 
-ln -sf $HOME/Sources/OSGP/Config/scripts/build_osgp_sources.sh $HOME/Sources/OSGP/b.sh
+ln -sf $BASE/Sources/OSGP/Config/scripts/build_osgp_sources.sh $BASE/Sources/OSGP/b.sh
 
-echo "- create scripts dir in $HOME ..."
-mkdir -p $HOME/scripts
+echo "- create scripts dir in $BASE ..."
+mkdir -p $BASE/scripts
 
-ln -sf $HOME/Sources/OSGP/Config/scripts/create_backup_osgp_dbs.sh $HOME/scripts/create_backup_osgp_dbs.sh
-ln -sf $HOME/Sources/OSGP/Config/scripts/restore_backup_osgp_dbs.sh $HOME/scripts/restore_backup_osgp_dbs.sh
+ln -sf $BASE/Sources/OSGP/Config/scripts/create_backup_osgp_dbs.sh $BASE/scripts/create_backup_osgp_dbs.sh
+ln -sf $BASE/Sources/OSGP/Config/scripts/restore_backup_osgp_dbs.sh $BASE/scripts/restore_backup_osgp_dbs.sh
 
 # Add scripts path to the path so that the development scripts can be found (introduced for database backup scripts
-! grep -q "$HOME/scripts" $HOME/.bashrc && echo "PATH=\"$HOME/scripts:\$PATH\"" >> $HOME/.bashrc
+! grep -q "$BASE/scripts" $BASE/.bashrc && echo "PATH=\"$BASE/scripts:\$PATH\"" >> $BASE/.bashrc
 # Adds cm2 alias so that you can easily clean your maven repository before building (e.g. `cm2 && mvn install`).
-! grep -q "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" $HOME/.bashrc && echo "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" >> $HOME/.bashrc
+! grep -q "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" $BASE/.bashrc && echo "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" >> $BASE/.bashrc
 
 echo "Done setting up OSGP development environment."

--- a/scripts/create-symlinks.sh
+++ b/scripts/create-symlinks.sh
@@ -1,94 +1,134 @@
 #!/bin/bash
 
-echo "Extending OSGP development environment for OSGP & SSS development ..."
-
-if [ $HOME ]
+if [ ! $HOME ]
 then
-    SOURCEDIR=$HOME/Sources/SmartSocietyServices
-    echo "HOME dir was set, source directory is $SOURCEDIR"
-else
-    SOURCEDIR=/home/dev/Sources/SmartSocietyServices
-    echo "HOME dir was not set, source directory is $SOURCEDIR"
+    echo "HOME dir was not set, setting to /home/dev"
+    HOME=/home/dev
 fi
-TARGETDIR=/etc/osp/
 
-echo "- copying the automatic tests files to $TARGETDIR/test ..."
-cp -f $SOURCEDIR/Smart-Meter-Integration/cucumber-integration-tests/src/test/resources/sm-integration-cucumber.properties $TARGETDIR/samples/test/
-cp -f $SOURCEDIR/Integration-Tests/cucumber-tests-webapps-web-core/src/test/resources/cucumber-webapps.properties $TARGETDIR/samples/test/
+SOURCEDIR=$HOME/Sources/OSGP
+TARGETDIR=/etc/osp
 
-echo "- copying the SSS configuration files to $TARGETDIR/samples and extending them with .sample ..."
-cp -f $SOURCEDIR/Smart-Meter-Integration/sm-integration/src/main/resources/sm-integration.properties $TARGETDIR/samples/sm-integration.properties.sample
-cp -f $SOURCEDIR/Smart-Meter-Integration/sm-integration/src/main/resources/logback.xml $TARGETDIR/samples/sm-integration-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/web-owner/src/main/resources/web-owner.properties $TARGETDIR/samples/web-owner.properties.sample
-cp -f $SOURCEDIR/Webapps/web-owner/src/main/resources/logback.xml $TARGETDIR/samples/web-owner-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/web-operator/src/main/resources/web-operator.properties $TARGETDIR/samples/web-operator.properties.sample
-cp -f $SOURCEDIR/Webapps/web-operator/src/main/resources/logback.xml $TARGETDIR/samples/web-operator-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/proxy-server/src/main/resources/proxy-server.properties $TARGETDIR/samples/proxy-server.properties.sample
-cp -f $SOURCEDIR/Webapps/proxy-server/src/main/resources/logback.xml $TARGETDIR/samples/proxy-server-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/osgp-webservice-client/src/main/resources/osgp-webservice-client.properties $TARGETDIR/samples/osgp-webservice-client.properties.sample
-cp -f $SOURCEDIR/Webapps/web-api-user-management/src/main/resources/web-api-user-management.properties $TARGETDIR/samples/web-api-user-management.properties.sample
-cp -f $SOURCEDIR/Webapps/web-api-user-management/src/main/resources/logback.xml $TARGETDIR/samples/web-api-user-management-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/web-api-net-management/src/main/resources/web-api-net-management.properties $TARGETDIR/samples/web-api-net-management.properties.sample
-cp -f $SOURCEDIR/Webapps/web-api-net-management/src/main/resources/logback.xml $TARGETDIR/samples/web-api-net-management-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/web-api-installation/src/main/resources/web-api-installation.properties $TARGETDIR/samples/web-api-installation.properties.sample
-cp -f $SOURCEDIR/Webapps/web-api-installation/src/main/resources/logback.xml $TARGETDIR/samples/web-api-installation-logback.xml.sample
-cp -f $SOURCEDIR/Webapps/osgp-simulator-dlms-triggered/src/main/resources/logback.xml $TARGETDIR/samples/osgp-simulator-dlms-triggered-logback.xml.sample
+echo "Setting up OSGP development environment ..."
 
-echo "- configuring proxyserver related files ..."
-sudo mkdir -p /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/flexovlca/certs/proxy-server/sign-key.der /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/flexovlca/certs/proxy-server/verify-key.der /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.crt /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.ks /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-broker.ts /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.crt /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.ks /etc/ssl/certs/proxy-server/
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/certificates/proxy/proxy-client.ts /etc/ssl/certs/proxy-server/
+# Create configuration directories and standard files.
+echo "- creating $TARGETDIR ..."
+sudo mkdir -p $TARGETDIR
+sudo chown -R dev:dev $TARGETDIR
 
-echo "- create $TARGETDIR/mailtemplates directory and linking files ..."
-mkdir -p /etc/osp/mailtemplates/
-ln -sf $HOME/Sources/SmartSocietyServices/Configuration/developers/master-template.html /etc/osp/mailtemplates/
-dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/mailtemplates"
-target="/etc/osp/mailtemplates/"
-for f in "$dir"/*; do
-  ln -sf "$f" "$target"
-done
-dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/mailtemplates/web-installation"
-for f in "$dir"/*; do
-  ln -sf "$f" "$target"
-done
+echo "- creating samples $TARGETDIR directory and $TARGETDIR/samples/Readme.md with directions about the sample files ..."
+mkdir -p $TARGETDIR/samples
+echo "OSGP Samples directory" > $TARGETDIR/samples/Readme.md
+echo "" >> $TARGETDIR/samples/Readme.md
+echo "This directory contains samples files how you could configure OSGP. These files will not be used. Use them by copying them to $TARGETDIR and remove the .sample extension." >> $TARGETDIR/samples/Readme.md
+echo "- *.properties.sample: Example property files for the given module." >> $TARGETDIR/samples/Readme.md
+echo "- *-logback.xml.sample: Example logback files for the given module." >> $TARGETDIR/samples/Readme.md
 
-mkdir -p /etc/osp/shipment/
-mkdir -p /etc/osp/substations/
+echo "- creating $TARGETDIR/test directory for automatic tests configuration ..."
+mkdir -p $TARGETDIR/test
+[ ! -f $TARGETDIR/global.properties ] && echo "# Global properties" > $TARGETDIR/global.properties
+[ ! -f $TARGETDIR/test/global-cucumber.properties ] && echo "# Global cucumber properties" > $TARGETDIR/test/global-cucumber.properties 
 
-echo "- create $TARGETDIR/styling directory and linking files ..."
-mkdir -p /etc/osp/styling/
-dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/css"
-target="/etc/osp/styling/"
-for f in "$dir"/*; do
-  ln -sf "$f" "$target"
-done
+echo "- setting security provider to SunPKCS11-NSS ..."
+[ $(/bin/grep -c signing.server.security.provider\=SunPKCS11-NSS $TARGETDIR/global.properties) -eq 0 ] && echo "signing.server.security.provider=SunPKCS11-NSS" >> $TARGETDIR/global.properties
+[ $(/bin/grep -c oslp.security.provider\=SunPKCS11-NSS $TARGETDIR/global.properties) -eq 0 ] && echo "oslp.security.provider=SunPKCS11-NSS" >> $TARGETDIR/global.properties
 
-echo "- create $TARGETDIR/logos directory and linking files ..."
-mkdir -p /etc/osp/logos/
-dir="$HOME/Sources/SmartSocietyServices/Configuration/developers/logos"
-target="/etc/osp/logos/"
-for f in "$dir"/*; do
-  ln -sf "$f" "$target"
-done
+# Now create all configuration sample files.
+mkdir -p $TARGETDIR/samples/test
+echo "- copying automatic tests configuration files to $TARGETDIR/test directory ..."
+cp $SOURCEDIR/Integration-Tests/cucumber-tests-platform/src/test/resources/cucumber-platform.properties $TARGETDIR/samples/test/
+cp $SOURCEDIR/Integration-Tests/cucumber-tests-platform-dlms/src/test/resources/cucumber-platform-dlms.properties $TARGETDIR/samples/test/
+
+echo "- copying OSGP configuration files to $TARGETDIR/samples directory and extending them with .sample ..."
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-admin/src/main/resources/osgp-adapter-domain-admin.properties $TARGETDIR/samples/osgp-adapter-domain-admin.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-admin/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-admin-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-core/src/main/resources/osgp-adapter-domain-core.properties $TARGETDIR/samples/osgp-adapter-domain-core.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-core-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-microgrids/src/main/resources/osgp-adapter-domain-microgrids.properties $TARGETDIR/samples/osgp-adapter-domain-microgrids.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-microgrids/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-microgrids-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-publiclighting/src/main/resources/osgp-adapter-domain-publiclighting.properties $TARGETDIR/samples/osgp-adapter-domain-publiclighting.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-publiclighting/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-publiclighting-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-smartmetering/src/main/resources/osgp-adapter-domain-smartmetering.properties $TARGETDIR/samples/osgp-adapter-domain-smartmetering.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-smartmetering/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-smartmetering-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-tariffswitching/src/main/resources/osgp-adapter-domain-tariffswitching.properties $TARGETDIR/samples/osgp-adapter-domain-tariffswitching.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-domain-tariffswitching/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-domain-tariffswitching-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties $TARGETDIR/samples/osgp-adapter-protocol-dlms.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-protocol-adapter-dlms/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-dlms-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-protocol-adapter-iec61850/src/main/resources/osgp-adapter-protocol-iec61850.properties $TARGETDIR/samples/osgp-adapter-protocol-iec61850.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-protocol-adapter-iec61850/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-iec61850-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp/src/main/resources/osgp-adapter-protocol-oslp.properties $TARGETDIR/samples/osgp-adapter-protocol-oslp.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-oslp-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties $TARGETDIR/samples/osgp-adapter-protocol-oslp-elster.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-adapter-protocol-oslp-elster/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-protocol-oslp-elster-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-admin/src/main/resources/osgp-adapter-ws-admin.properties $TARGETDIR/samples/osgp-adapter-ws-admin.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-admin/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-admin-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties $TARGETDIR/samples/osgp-adapter-ws-core.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-core-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-shared-db/src/main/resources/osgp-adapter-ws-shared-db.properties $TARGETDIR/samples/osgp-adapter-ws-shared-db.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-microgrids/src/main/resources/osgp-adapter-ws-microgrids.properties $TARGETDIR/samples/osgp-adapter-ws-microgrids.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-microgrids/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-microgrids-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-publiclighting/src/main/resources/osgp-adapter-ws-publiclighting.properties $TARGETDIR/samples/osgp-adapter-ws-publiclighting.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-publiclighting/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-publiclighting-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties $TARGETDIR/samples/osgp-adapter-ws-smartmetering.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-smartmetering/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-smartmetering-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-tariffswitching/src/main/resources/osgp-adapter-ws-tariffswitching.properties $TARGETDIR/samples/osgp-adapter-ws-tariffswitching.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-adapter-ws-tariffswitching/src/main/resources/logback.xml $TARGETDIR/samples/osgp-adapter-ws-tariffswitching-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-core/src/main/resources/osgp-core.properties $TARGETDIR/samples/osgp-core.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-core/src/main/resources/logback.xml $TARGETDIR/samples/osgp-core-logback.xml.sample
+cp -f $SOURCEDIR/Platform/osgp-logging/src/main/resources/osgp-logging.properties $TARGETDIR/samples/osgp-logging.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-logging/src/main/resources/logback.xml $TARGETDIR/samples/osgp-logging-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/signing-server/src/main/resources/signing-server.properties $TARGETDIR/samples/signing-server.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/signing-server/src/main/resources/logback.xml $TARGETDIR/samples/signing-server-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/web-device-simulator/src/main/resources/web-device-simulator.properties $TARGETDIR/samples/web-device-simulator.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/web-device-simulator/src/main/resources/logback.xml $TARGETDIR/samples/web-device-simulator-logback.xml.sample
+cp -f $SOURCEDIR/Protocol-Adapter-OSLP/osgp-core-db-api/src/main/resources/osgp-core-db-api.properties $TARGETDIR/samples/osgp-core-db-api.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-IEC61850/osgp-core-db-api-iec61850/src/main/resources/osgp-core-db-api-iec61850.properties $TARGETDIR/samples/osgp-core-db-api-iec61850.properties.sample
+cp -f $SOURCEDIR/Protocol-Adapter-DLMS/osgp-jasper-interface/src/main/resources/jasper-interface.properties $TARGETDIR/samples/jasper-interface.properties.sample
+cp -f $SOURCEDIR/Platform/osgp-domain-logging/src/main/resources/osgp-domain-logging.properties $TARGETDIR/samples/osgp-domain-logging.properties.sample
+
+echo "- creating symlinks to device simulator ECDSA keypair ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_private.der /etc/ssl/certs
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_sim_ecdsa_public.der /etc/ssl/certs
+
+echo "- create symlinks to platform ECDSA keypair ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_private.der /etc/ssl/certs
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/oslp_test_ecdsa_public.der /etc/ssl/certs
+
+echo "- create symlinks to secret.aes ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/oslp/secret.aes /etc/ssl/certs
+
+echo "- create symlink to CA certificate ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/cacert.cer /etc/ssl/certs
+
+echo "- create symlink to LianderNetManagement.pfx ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/LianderNetManagement.pfx /etc/ssl/certs
+
+echo "- create symlink to server certificate ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/certs/localhost.cert.pem /etc/ssl/certs
+
+echo "- create symlink to server private key ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/osgp-ca/private/localhost.key.pem /etc/ssl/private
+
+echo "- create symlink to keystore ..."
+sudo ln -sf $HOME/Sources/OSGP/Config/certificates/trust.jks /etc/ssl/certs
 
 echo "- create symlink to apache vhost and remove the link to the 000-default.conf vhost ..."
-sudo ln -sf $HOME/Sources/SmartSocietyServices/Configuration/developers/apache2/flexovl-vhost /etc/apache2/sites-enabled/vhost.conf
+sudo ln -sf $HOME/Sources/OSGP/Config/apache-httpd/vhost.conf /etc/apache2/sites-enabled
+sudo rm -f /etc/apache2/sites-enabled/000-default.conf
 sudo service apache2 restart
 
-echo "- creating build script for SSS in $HOME/Sources/SmartSocietyServices ..."
-ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/build_sss_sources.sh $HOME/Sources/SmartSocietyServices/b.sh
+# Create sym-link to build script. 
+ln -sf $HOME/Sources/OSGP/Config/scripts/build_osgp_sources.sh $HOME/Sources/OSGP/b.sh
 
-echo "- creating SSS link to $HOME/Sources/SmartSocietyServices ..."
-[ ! -L $HOME/Sources/SSS ] && ln -sf $HOME/Sources/SmartSocietyServices/ $HOME/Sources/SSS
+echo "- create scripts dir in $HOME ..."
+mkdir -p $HOME/scripts
 
-echo "- creating links to create backup and restore databases ..."
-ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/create_backup_osgp_and_sss_dbs.sh $HOME/scripts/
-ln -sf $HOME/Sources/SmartSocietyServices/Configuration/scripts/restore_backup_osgp_and_sss_dbs.sh $HOME/scripts/
+ln -sf $HOME/Sources/OSGP/Config/scripts/create_backup_osgp_dbs.sh $HOME/scripts/create_backup_osgp_dbs.sh
+ln -sf $HOME/Sources/OSGP/Config/scripts/restore_backup_osgp_dbs.sh $HOME/scripts/restore_backup_osgp_dbs.sh
 
-echo "Done extending the OSGP development environment for OSGP & SSS development."
+# Add scripts path to the path so that the development scripts can be found (introduced for database backup scripts
+! grep -q "$HOME/scripts" $HOME/.bashrc && echo "PATH=\"$HOME/scripts:\$PATH\"" >> $HOME/.bashrc
+# Adds cm2 alias so that you can easily clean your maven repository before building (e.g. `cm2 && mvn install`).
+! grep -q "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" $HOME/.bashrc && echo "alias cm2='rm -rf ~/.m2/repository/org/osgp && rm -rf ~/.m2/repository/com/alliander'" >> $HOME/.bashrc
+
+echo "Done setting up OSGP development environment."


### PR DESCRIPTION
Fix voor het OSGP Vagrant image; bij het installeren van het image mbv Vagrant worden de symbolic links niet goed gezet omdat er uit wordt gegaan van de HOME directory variabele, en deze is waarschijnlijk leeg bij installatie; deze fix zet de HOME dir op /home/dev