### PR TITLE
Initializes submodules for PublicLightingDemoApp

### DIFF
--- a/puppet/manifests/repositories-checkout-development-branch.pp
+++ b/puppet/manifests/repositories-checkout-development-branch.pp
@@ -42,4 +42,9 @@ node 'dev-box' {
 		returns => [0,128],
 	}
 
+	exec { 'PublicLightingDemoApp repo':
+		command => '/bin/sh -c "cd /home/dev/Sources/OSGP/PublicLightingDemoApp; /usr/bin/git checkout development"',
+		returns => [0,128],
+	}
+
 }

--- a/puppet/manifests/repositories-init-submodules.pp
+++ b/puppet/manifests/repositories-init-submodules.pp
@@ -27,4 +27,9 @@ node 'dev-box' {
                 returns => [0,1,128],
         }
 
+	exec { 'PublicLightingDemoApp repo':
+		command => '/bin/sh -c "cd /home/dev/Sources/OSGP/PublicLightingDemoApp; /usr/bin/git submodule update --init --recursive"',
+		returns => [0,1,128],
+	}
+
 }


### PR DESCRIPTION
Makes sure that the puppet scripts for setting
up a development image check out the development
branch and initialize the submodules for the
public lighting demo app as well as for the
other repos.