### PR TITLE
OC-305 Use OSGP client certificate to send notifications

### DIFF
--- a/scripts/create-symlinks.sh
+++ b/scripts/create-symlinks.sh
@@ -116,6 +116,9 @@ sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/LianderNetManag
 echo "- create symlink to test-org.pfx ..."
 sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/test-org.pfx /etc/ssl/certs
 
+echo "- create symlink to OSGP.pfx ..."
+sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/OSGP.pfx /etc/ssl/certs
+
 echo "- create symlink to server certificate ..."
 sudo ln -sf $BASE/Sources/OSGP/Config/certificates/osgp-ca/certs/localhost.cert.pem /etc/ssl/certs
 


### PR DESCRIPTION
Adds a symlink for OSGP.pfx so it can be used as OSGP
client certificate sending notifications.