### PR TITLE
Fix type in url from last commit + script cleanup

### DIFF
--- a/puppet/install-puppet.sh
+++ b/puppet/install-puppet.sh
@@ -10,11 +10,11 @@ echo "preparing puppet.deb file";
 sudo dpkg -i ~/Downloads/puppet-release-xenial.deb
 
 echo "running apt-get update";
-sudo apt-get update
+sudo apt-get -o DPkg::Options::=--force-confdef update
 
 echo "installing puppet";
-sudo apt-get install -y puppet-common
-sudo apt-get install -y puppet
+sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet-common
+sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet
 
 echo "running puppet --version";
 echo $(puppet --version)

--- a/puppet/install-puppet.sh
+++ b/puppet/install-puppet.sh
@@ -3,7 +3,6 @@
 # Run this script as your user, not as root!
 # The script will prompt for root password (for the first sudo command) and will prompt if you want to continue with installation of packages (for the apt-get install command).
 
-export DEBIAN_FRONTEND=noninteractive
 echo "downloading puppet.deb file to ~/Downloads folder";
 wget -q -P ~/Downloads - https://apt.puppetlabs.com/puppet-release-xenial.deb
 
@@ -11,10 +10,10 @@ echo "preparing puppet.deb file";
 sudo dpkg -i ~/Downloads/puppet-release-xenial.deb
 
 echo "running apt-get update";
-sudo apt-get -o DPkg::Options::=--force-confdef update
+sudo apt-get -qqo DPkg::Options::=--force-confdef update
 
 echo "installing puppet";
-sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet puppet-common
+sudo apt-get -qqo DPkg::Options::=--force-confdef install -y puppet puppet-common
 
 echo "running puppet --version";
 echo $(puppet --version)

--- a/puppet/install-puppet.sh
+++ b/puppet/install-puppet.sh
@@ -3,6 +3,7 @@
 # Run this script as your user, not as root!
 # The script will prompt for root password (for the first sudo command) and will prompt if you want to continue with installation of packages (for the apt-get install command).
 
+export DEBIAN_FRONTEND=noninteractive
 echo "downloading puppet.deb file to ~/Downloads folder";
 wget -q -P ~/Downloads - https://apt.puppetlabs.com/puppet-release-xenial.deb
 
@@ -13,8 +14,7 @@ echo "running apt-get update";
 sudo apt-get -o DPkg::Options::=--force-confdef update
 
 echo "installing puppet";
-sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet-common
-sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet
+sudo apt-get -o DPkg::Options::=--force-confdef install -y puppet puppet-common
 
 echo "running puppet --version";
 echo $(puppet --version)

--- a/puppet/install-puppet.sh
+++ b/puppet/install-puppet.sh
@@ -10,10 +10,10 @@ echo "preparing puppet.deb file";
 sudo dpkg -i ~/Downloads/puppet-release-xenial.deb
 
 echo "running apt-get update";
-sudo apt-get -qqo DPkg::Options::=--force-confdef update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confdef update
 
 echo "installing puppet";
-sudo apt-get -qqo DPkg::Options::=--force-confdef install -y puppet puppet-common
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confdef install -y puppet puppet-common
 
 echo "running puppet --version";
 echo $(puppet --version)

--- a/puppet/manifests/soapui.pp
+++ b/puppet/manifests/soapui.pp
@@ -6,7 +6,7 @@ node 'dev-box' {
 
 	# Soap-UI
 	exec { 'wget soap-ui':
-		command => "/usr/bin/wget -q -O /home/dev/Downloads/osgp/SoapUI-${version}-linux-bin.tar.gz http:///s3.amazonaws.com/downloads.eviware/soapuios/${version}/SoapUI-${version}-linux-bin.tar.gz",
+		command => "/usr/bin/wget -q -O /home/dev/Downloads/osgp/SoapUI-${version}-linux-bin.tar.gz http://s3.amazonaws.com/downloads.eviware/soapuios/${version}/SoapUI-${version}-linux-bin.tar.gz",
 		onlyif => '/usr/bin/test ! -f /home/dev/Tools/SoapUI',
 		timeout => 1800,		
 		returns => [0, 4],

--- a/puppet/manifests/vm-corrections.pp
+++ b/puppet/manifests/vm-corrections.pp
@@ -12,7 +12,7 @@ node 'dev-box' {
 	}
 
 	exec { 'Update': 
-		command => '/usr/bin/apt update',
+		command => '/usr/bin/apt-get update',
 		require => Exec['Remove original xenial mate file']
 	}
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 	config.vm.box = "cxtlabs/vagrant-ubuntu-16.04-mate"
-	
+
 	config.vm.provider "virtualbox" do |vb|
 		vb.name = "OSGP Development"
 		vb.gui = true
@@ -13,31 +13,31 @@ Vagrant.configure("2") do |config|
 		# Disable 3d acceleration because some programs crash on it.
 		vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
 
-		# Enabling copy/paste to/from VM         
+		# Enabling copy/paste to/from VM
         vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
 
 		# Add cdrom
         vb.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--port", "0", "--device", "0", "--type", "dvddrive", "--medium", "emptydrive"]
 	end
-  
+
 	config.vm.define :osgp_development do |osgp_oss_config|
 		osgp_oss_config.vm.hostname="dev-box"
 	end
-  
+
 	config.vm.provision "shell", inline: <<-SHELL
 		# Clone config repo for user Vagrant
-		apt-get install -y git
+		apt-get -o DPkg::Options::=--force-confdef install -y git;
 		su vagrant -c "mkdir -p ~/repos/OSGP";
-		su vagrant -c "git clone -b "development" https://github.com/OSGP/Config.git ~/repos/OSGP/Config"
+		su vagrant -c "git clone -b "development" https://github.com/OSGP/Config.git ~/repos/OSGP/Config 2>&1";
 
 		# Install puppet
-		su vagrant -c "/home/vagrant/repos/OSGP/Config/puppet/install-puppet.sh"
-		
+		su vagrant -c "/home/vagrant/repos/OSGP/Config/puppet/install-puppet.sh";
+
 		# Trigger puppet installation
-		su vagrant -c "cd /home/vagrant/repos/OSGP/Config/puppet/;/home/vagrant/repos/OSGP/Config/puppet/run-puppet.sh"
+		su vagrant -c "cd /home/vagrant/repos/OSGP/Config/puppet/;/home/vagrant/repos/OSGP/Config/puppet/run-puppet.sh";
 	SHELL
-	
+
 	# Provision some user specific settings/configuration/packages
 	user_config_file=".user-dev-box.sh"
 	if File.file?(File.join(Dir.home, user_config_file))
@@ -45,4 +45,3 @@ Vagrant.configure("2") do |config|
 	end
 
 end
-

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   
 	config.vm.provision "shell", inline: <<-SHELL
 		# Clone config repo for user Vagrant
-		apt install -y git
+		apt-get install -y git
 		su vagrant -c "mkdir -p ~/repos/OSGP";
 		su vagrant -c "git clone -b "development" https://github.com/OSGP/Config.git ~/repos/OSGP/Config"
 


### PR DESCRIPTION
The protocol part of the url used in the SoapUI paths contained a typo. This PR fixes this.

There are also some scripting cleanups resulting in a cleaner "vagrant up" feedback. Only one error remains now.

vagrant up now builds a working vm.