### PR TITLE
Updated the Eclipse puppet script so that it is working properly

### DIFF
--- a/puppet/manifests/eclipse.pp
+++ b/puppet/manifests/eclipse.pp
@@ -7,7 +7,7 @@ node 'dev-box' {
 
 	# Eclipse EE for Webdevelopers, Luna.
 	exec { 'wget eclipse':
-		command => "/usr/bin/wget -q -O /home/dev/Downloads/osgp/eclipse-${major}-${version}.tar.gz http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/$major/$version/eclipse-jee-2020-03-R-incubation-linux-gtk-x86_64.tar.gz",
+		command => "/usr/bin/wget -q -O /home/dev/Downloads/osgp/eclipse-${major}-${version}.tar.gz http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/$major/$version/eclipse-jee-$major-$version-incubation-linux-gtk-x86_64.tar.gz&r=1",
 		creates => "/home/dev/Downloads/osgp/eclipse-${major}-${version}.tar.gz",
 		timeout => 1800,
 		returns => [0, 4],
@@ -34,11 +34,6 @@ node 'dev-box' {
 
 	exec { 'install cucumber-eclipse plugin':
 		command => '/home/dev/Tools/eclipse/eclipse -application org.eclipse.equinox.p2.director -nosplash -repository http://cucumber.github.io/cucumber-eclipse/update-site -installIUs cucumber.eclipse.feature.feature.group',
-		require => File['create eclipse link']
-	}
-
-	exec { 'update m2eclipse-mavenarchiver':
-		command => '/home/dev/Tools/eclipse/eclipse -application org.eclipse.equinox.p2.director -nosplash -repository https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/LATEST/ -installIUs org.sonatype.m2e.mavenarchiver.feature.feature.group',
 		require => File['create eclipse link']
 	}
 


### PR DESCRIPTION
The Eclipse puppet script is updated so that it downloads the correct Eclipse image and does not install the Maven archiver