### PR TITLE
Update OSGP.xml

### DIFF
--- a/code-format-settings/intellij/code-format/OSGP.xml
+++ b/code-format-settings/intellij/code-format/OSGP.xml
@@ -2,7 +2,7 @@
   <option name="FORMATTER_TAGS_ENABLED" value="true" />
   <JavaCodeStyleSettings>
     <option name="SUBCLASS_NAME_SUFFIX" value="" />
-    <option name="USE_FQ_CLASS_NAMES" value="true" />
+    <option name="USE_FQ_CLASS_NAMES" value="false" />
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3999" />
     <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">


### PR DESCRIPTION
Removed fully qualified classnames requirement. This option makes the code pretty unreadable.