### PR TITLE
Adds osgp-secret-management to vhost config

### DIFF
--- a/apache-httpd/vhost.conf
+++ b/apache-httpd/vhost.conf
@@ -8,6 +8,7 @@ ServerName localhost
     Redirect permanent /osgp-adapter-ws-tariffswitching https://localhost/osgp-adapter-ws-tariffswitching
     Redirect permanent /osgp-adapter-ws-microgrids https://localhost/osgp-adapter-ws-microgrids
     Redirect permanent /osgp-adapter-ws-distributionautomation https://localhost/osgp-adapter-ws-distributionautomation
+    Redirect permanent /osgp-secret-management https://localhost/osgp-secret-management
     Redirect permanent /web-device-simulator https://localhost/web-device-simulator
     Redirect permanent /web-demo-app https://localhost/web-demo-app
 </VirtualHost>
@@ -43,9 +44,11 @@ ServerName localhost
             ProxyPassReverse /osgp-adapter-ws-microgrids /osgp-adapter-ws-microgrids
             ProxyPass /osgp-adapter-ws-distributionautomation ajp://localhost:8009/osgp-adapter-ws-distributionautomation
             ProxyPassReverse /osgp-adapter-ws-distributionautomation /osgp-adapter-ws-distributionautomation
+            ProxyPass /osgp-secret-management ajp://localhost:8009/osgp-secret-management
+            ProxyPassReverse /osgp-secret-management /osgp-secret-management
             ProxyPass /web-device-simulator ajp://localhost:8009/web-device-simulator
             ProxyPassReverse /web-device-simulator /web-device-simulator
-            
+
             ProxyPass /web-demo-app ajp://localhost:8009/web-demo-app
             ProxyPassReverse /web-demo-app /web-demo-app
         </IfModule>
@@ -121,5 +124,16 @@ ServerName localhost
         <Location /osgp-adapter-ws-smartmetering/wsdl>
             SSLVerifyClient none
         </Location>
+
+        # OSGP Secret Management
+        <Location /osgp-secret-management>
+            SSLVerifyClient require
+            SSLVerifyDepth 1
+            SSLOptions +ExportCertData
+        </Location>
+        <Location /osgp-secret-management/ws/SecretManagement/secretManagement.wsdl>
+            SSLVerifyClient none
+        </Location>
+
     </VirtualHost>
 </IfModule>


### PR DESCRIPTION
Adds redirects and SSL verification settings to vhost for
osgp-secret-management so that the secret management endpoint is
available in for instance the Cucumber tests for the smart metering
domain.