### PR TITLE
Updates license header code templates

### DIFF
--- a/code-format-settings/eclipse/code-templates/codetemplates.xml
+++ b/code-format-settings/eclipse/code-templates/codetemplates.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="false" context="filecomment_context" deleted="false" description="Comment for created Java files" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.filecomment" name="filecomment">/**
- * Copyright 2017 Smart Society Services B.V.
+ * Copyright ${year} Alliander N.V.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  */</template></templates>

--- a/code-format-settings/intellij/code-templates/license.txt
+++ b/code-format-settings/intellij/code-templates/license.txt
@@ -1,8 +1,9 @@
 /**
- * Copyright 2019 Smart Society Services B.V.
+ * Copyright ${YEAR} Alliander N.V.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  */


### PR DESCRIPTION
Updates the code templates with the license header.
The templates refer to the current year instead of a fixed year.
The templates refer to Alliander N.V. instead of Smart Society Services.

Reformatted the lines to match those shown at the Apache URL, and
removed the indentation before the URL in the template, as it is prone
to be removed upon formatting the code in the editor, which is
inconvenient.