### PR TITLE
FDP-229 ~ Changes JIRA link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,4 @@ Grid eXchange Fabric detailed documentation:
 * [documentation.gxf.lfenergy.org](https://documentation.gxf.lfenergy.org)
 
 Grid eXchange Fabric issue tracker:
-* [Grid eXchange Fabric Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues)
-
-Questions and discussions:
-* [Grid eXchange Fabric Discourse](https://opensmartgridplatform.discourse.group/)
+* [github.com/OSGP/Documentation/issues](https://github.com/OSGP/Documentation/issues)


### PR DESCRIPTION
- replaced JIRA link by issues page of Documentation 
- removed discourse link because it is not used and no longer active