### PR TITLE
[Documentation] A few clarifications for the open source community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
-# Thank you for contributing!
+# How to Contribute
 
-Please comply with the [code of conduct](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Code-of-conduct.html) and [documentation guidelines](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Contributing-to-documentation.html).
+We'd love to accept your patches and contributions to this project. There are just a couple guidelines you need to follow before making a change.
+
+## Code of conduct
+
+Please comply with the [code of conduct](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Code-of-conduct.html) 
 
 ## To get started
 
@@ -15,6 +19,22 @@ Please comply with the [code of conduct](https://documentation.gxf.lfenergy.org/
 5. Assign a maintainer to accept/evaluate your pull request. The current maintainer can be found in the [documentation](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Governance.html).
 
 If you have any questions, open an issue.
+
+## Developer tools and technical guidelines
+
+Please find the [developer tools and technical guidelines here](https://documentation.gxf.lfenergy.org/Opensourcecommunity/ToolsguidelinesCI.html).
+
+## Documentation guidelines
+
+Please find the [documentation guidelines here](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Contributing-to-documentation.html).
+
+## Contribution guidelines
+
+Please find the [more detailed contribution guidelines here](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Contributing-to-the-code.html).
+
+## Governance 
+
+The basic principle is that decisions are based on consensus. If this decision making process takes too long or a decision is required, the Technical Steering committee has the authority to make a decision. Please read [this page](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Governance.html) for more information on the governance.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ Grid eXchange Fabric detailed documentation:
 
 Grid eXchange Fabric issue tracker:
 * [github.com/OSGP/Documentation/issues](https://github.com/OSGP/Documentation/issues)
+
+## License
+
+This project is licensed under the Apache 2.0 license - see the LICENSE file for details
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Contact
+
+If you have a question, please read [GXF wiki contact page](https://documentation.gxf.lfenergy.org/Opensourcecommunity/Communication-and-contact.html) how to best contact us.


### PR DESCRIPTION
I made a few clarifications in the readme.md and contribution.md for the open source community.

This includes:

- adding license, contributing and contact information in the readme.md
- adding links to developers tools, contribution guidelines and governance information in the contributing.md.

Furthermore, the GXF charter (https://github.com/lf-energy/foundation/blob/main/project_charters/grid-exchange-frabric-charter.pdf) requires us to have governance information in our contributing file.

Please review and make changes if you see necessary.