### PR TITLE
FDP-109 Create database for throttling service

### DIFF
--- a/sql/create-users-and-databases.sql
+++ b/sql/create-users-and-databases.sql
@@ -94,7 +94,13 @@ CREATE DATABASE osgp_secret_management
     WITH OWNER = osp_admin
     ENCODING = 'UTF8'
     TABLESPACE = pg_default
-     CONNECTION LIMIT = -1;
+    CONNECTION LIMIT = -1;
+
+CREATE DATABASE osgp_throttling
+  WITH OWNER = osp_admin
+       ENCODING = 'UTF8'
+       TABLESPACE = pg_default
+       CONNECTION LIMIT = -1;
 
 -- Create the readonly users
 


### PR DESCRIPTION
Adds a create statement to set up an osgp_throttling database to the SQL
script for creation of users and databases.
