### PR TITLE
FDP-526 Remove MQTT protocol database creation

### DIFF
--- a/sql/create-users-and-databases.sql
+++ b/sql/create-users-and-databases.sql
@@ -30,12 +30,6 @@ CREATE DATABASE osgp_adapter_protocol_dlms
        TABLESPACE = pg_default
        CONNECTION LIMIT = -1;
 
-CREATE DATABASE osgp_adapter_protocol_mqtt
-  WITH OWNER = osp_admin
-       ENCODING = 'UTF-8'
-       TABLESPACE = pg_default
-       CONNECTION LIMIT = -1;
-
 CREATE DATABASE osgp_adapter_ws_smartmetering
   WITH OWNER = osp_admin
        ENCODING = 'UTF-8'


### PR DESCRIPTION
Removes the creation of database osgp_adapter_protocol_mqtt from SQL script create-users-and-databases.sql.
The database was used to store MQTT broker devices, which we no longer use with the configured MQTT broker.