### PR TITLE
errors during vagrant project installing

### DIFF
--- a/puppet/manifests/install-dev-env.pp
+++ b/puppet/manifests/install-dev-env.pp
@@ -2,7 +2,7 @@
 
 node 'dev-box' {
 
-	$mavenVersion="3.8.6"
+	$mavenVersion="3.8.8"
 
 	# Everybody needs vim.
 	package { 'vim':

--- a/puppet/manifests/soapui.pp
+++ b/puppet/manifests/soapui.pp
@@ -27,7 +27,7 @@ node 'dev-box' {
 	}
 
 	exec { 'wget icon':
-		command => "/usr/bin/wget -q -O /home/dev/Tools/SoapUI/logo.png https://symbols.getvecta.com/stencil_25/77_soapui.5113237b76.png",
+		command => "/usr/bin/wget -q -O /home/dev/Tools/SoapUI/logo.png https://symbols.getvecta.com/stencil_25/79_soapui.5113237b76.png",
 		onlyif => '/usr/bin/test ! -f /home/dev/Tools/SoapUI/logo.png',
 		require => File['create soapui link']
 	}


### PR DESCRIPTION

`MAVEN`
```
 default: ##############################################################
    default: ## Installing Dev. Env.                                     ##
    default: ##############################################################
    default: Notice: Compiled catalog for dev-box.mikronika.com.pl in environment production in 0.03 seconds
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[creating osgp download folder]/returns: executed successfully
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[chown osgp download folder]/returns: executed successfully
    default: Notice: Applied catalog in 0.04 seconds
    default: Notice: Compiled catalog for dev-box.mikronika.com.pl in environment production in 0.02 seconds
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[creating tools folder]/returns: executed successfully
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[chown tools folder]/returns: executed successfully
    default: Notice: Applied catalog in 0.04 seconds
    default: Notice: Compiled catalog for dev-box.mikronika.com.pl in environment production in 0.04 seconds
    default: Notice: /Stage[main]/Main/Node[dev-box]/Package[htop]/ensure: created
    default: Notice: /Stage[main]/Main/Node[dev-box]/Package[pgadmin3]/ensure: created
    default: Error: '/usr/bin/wget -q -P /home/dev/Tools https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz && /bin/tar xzf /home/dev/Tools/apache-maven-3.8.6-bin.tar.gz -C /home/dev/Tools && /bin/ln -s /home/dev/Tools/apache-maven-3.8.6/bin/mvn /usr/bin/mvn' returned 8 instead of one of [0,4]
    default: Error: /Stage[main]/Main/Node[dev-box]/Exec[maven]/returns: change from 'notrun' to ['0', '4'] failed: '/usr/bin/wget -q -P /home/dev/Tools https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz && /bin/tar xzf /home/dev/Tools/apache-maven-3.8.6-bin.tar.gz -C /home/dev/Tools && /bin/ln -s /home/dev/Tools/apache-maven-3.8.6/bin/mvn /usr/bin/mvn' returned 8 instead of one of [0,4]
```

`SOAP`
```
 default: ##############################################################
    default: ## Installing soapui                                        ##
    default: ##############################################################
    default: Notice: Compiled catalog for dev-box.mikronika.com.pl in environment production in 0.03 seconds
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[wget soap-ui]/returns: executed successfully
    default: Notice: /Stage[main]/Main/Node[dev-box]/Exec[unpack soap-ui]/returns: executed successfully
    default: Notice: /Stage[main]/Main/Node[dev-box]/File[create soapui link]/ensure: created
    default: Error: '/usr/bin/wget -q -O /home/dev/Tools/SoapUI/logo.png https://symbols.getvecta.com/stencil_25/77_soapui.5113237b76.png' returned 8 instead of one of [0]
    default: Error: /Stage[main]/Main/Node[dev-box]/Exec[wget icon]/returns: change from 'notrun' to ['0'] failed: '/usr/bin/wget -q -O /home/dev/Tools/SoapUI/logo.png https://symbols.getvecta.com/stencil_25/77_soapui.5113237b76.png' returned 8 instead of one of [0]
    default: Notice: Applied catalog in 76.27 seconds
    ```